### PR TITLE
Suggesting a different bio style

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,11 @@
             <div class="profile">
               <h4>malwine</h4>
               <div class="location">berlin | de</div>
-              <p>draws since 1995, sketchnotes since 2015, likes both coding and comics, interested in JavaScript, Ruby, WebXR, frontend and community conferences</p>
+              <p><strong>interested in:</strong> JavaScript,
+                Ruby, WebXR, frontend and community conferences,
+                diverse speaker lineups and topics<br>
+                <strong>travel area:</strong> Europe
+              </p>
             </div>
           </div>
           <div class="item">


### PR DESCRIPTION
Suggesting a new bio to suit this userstory:
```
As a customer 
I'd like to see which sketchnoter fits to my conference and if they travel to my area
so I can invite them.
```

Some of us may be restricted in the area they travel or what they like to do.
Bio could look like this:
```
Interests: Backend conferences, Kubernetes
Travel area: U.S.
```
```
Interests: JS, CSS and frontend in general
Travel area: all around the globe
```


