### PR TITLE
Reformat bios

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,20 @@
             </div>
             <div class="profile">
               <h4>daiyi</h4>
-              <div class="location">oakland | ca | usa</div>
-              <p>likes mountains, sunshine, and alpine lakes \o/ clojure <3 js <3 everything is interesting, community is a trust fall.</p>
+              <div class="location">oakland . ca . usa</div>
+              <p>likes bicycles, smol video games, & climbing \o/ </p>
+              <p>
+                <b>interested in:</b>
+                js & clojure,
+                distsys & observability,
+                cross-disciplinary/research/theoretical cs,
+                community, art+tech
+              </p>
+              <p>
+                <b>travel area:</b> 2.5-hour flight radius from SFO/OAK;
+                pretty done with airplanes though so I prefer local!
+                you could probably convince me to go most places that are near a mountain
+              </p>
             </div>
           </div>
           <div class="item">
@@ -58,11 +70,13 @@
             </div>
             <div class="profile">
               <h4>malwine</h4>
-              <div class="location">berlin | de</div>
-              <p><strong>interested in:</strong> JavaScript,
+              <div class="location">berlin . de</div>
+              <p><b>interested in:</b> JavaScript,
                 Ruby, WebXR, frontend and community conferences,
-                diverse speaker lineups and topics<br>
-                <strong>travel area:</strong> Europe
+                diverse speaker lineups and topics
+              </p>
+              <p>
+                <b>travel area:</b> Europe
               </p>
             </div>
           </div>
@@ -74,8 +88,14 @@
             </div>
             <div class="profile">
               <h4>fabian</h4>
-              <div class="location">hamburg | de</div>
-              <p>design, development and community</p>
+              <div class="location">hamburg . de</div>
+              <p>
+                <b>interested in:</b> design, development and community
+              </p>
+              <p>
+                <b>travel area:</b> -
+              </p>
+              <p>
             </div>
           </div>
         </div>

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -15,7 +15,7 @@ img {
 body {
   font-family: Helvetica;
   font-family: "courier new", monospace;
-/*   margin: 0;
+  /*   margin: 0;
   padding: 0; */
 }
 
@@ -52,6 +52,7 @@ h4 {
   padding: 20px;
   background: white;
   transition: 200ms background ease;
+  word-break: break-word;
 }
 
 .item:hover {
@@ -77,7 +78,7 @@ h4 {
 }
 
 .container.contributors {
-  width: 700px;
+  width: 800px;
 }
 
 .container.contributors .item {
@@ -133,8 +134,6 @@ li {
   width: 100%;
 }
 
-
-
 @media (max-width: 700px) {
   .container {
     width: 100%;
@@ -144,7 +143,7 @@ li {
     margin: -20px;
   }
   .items {
-    flex-wrap: wrap; 
+    flex-wrap: wrap;
   }
   .item {
     flex-basis: 100%;
@@ -167,5 +166,4 @@ li {
   .location {
     text-align: left;
   }
-  
 }


### PR DESCRIPTION
Following #4, a bit of restyling!

<img width="555" alt="screen shot 2018-05-24 at 13 36 23" src="https://user-images.githubusercontent.com/1589186/40513007-5cea55de-5f59-11e8-8e7d-31a84211167b.png">

For future css styleguide reference, let's prefer to use containing elements (such as `<p>` or `<div>` or `<span>`) to create spacing rather than breaks (`<br>`), so that it is easier to control the size of the spacing with css. 

Also note the semantic difference between using `<b>` vs `<strong>`: `<b>` is for making text pop out visually like a title, whereas `<strong>` means a contextual emphasis like if you are reading out loud you would say the word louder.